### PR TITLE
Replace outlier var declaration with let declaration

### DIFF
--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -26,7 +26,7 @@ import { WrapNoteInFolderCommand } from "./WrapNoteInFolderCommand";
 import { CopyLinkToClipboardCommand } from "./CopyLinkToClipboardCommand";
 
 
-var commands: Map<string, ICommand> = new Map<string, ICommand>();
+let commands: Map<string, ICommand> = new Map<string, ICommand>();
 
 function createCommands(obsidianProxy: IObsidianProxy, settings: IObsidianLinksSettings) {
     if (commands.size > 0) {


### PR DESCRIPTION
Replaces outlier `var` declaration with `let` declaration. `let` is used much more frequently in this repository.